### PR TITLE
improve import method when opencv and numpy not available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install numpy and opencv
-        run: pip3 install opencv-python numpy
-
       - name: Install archipel_utils
         run: pip3 install --user --no-use-pep517 --editable .
         shell: bash
+
+      - name: Run pytest without numpy and opencv
+        run: python -m pytest --cov=archipel_utils .
+
+      - name: Install numpy and opencv
+        run: pip3 install opencv-python numpy
 
       - name: Run pytest
         run: python -m pytest --cov=archipel_utils .

--- a/archipel_utils/__init__.py
+++ b/archipel_utils/__init__.py
@@ -13,19 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import warnings
-
-try:
-    from .data import *  # noqa
-except ImportError:
-    with warnings.catch_warnings():
-        warnings.simplefilter("always", ImportWarning)
-        warnings.warn(
-            "Missing packages, you will not be able to use archipel 'data' "
-            + "utils, others remain usable. To fix: pip install opencv numpy",
-            ImportWarning,
-        )
-
+from .data import *  # noqa
 from .msg import *  # noqa
 
 __version__ = "0.1.2"

--- a/archipel_utils/data.py
+++ b/archipel_utils/data.py
@@ -14,28 +14,44 @@ limitations under the License.
 """
 
 import base64
+import sys
 
-import cv2
-import numpy as np
+try:
+    import cv2
+    import numpy as np
+except ImportError:
+    pass
 
 
 def serialize_img(array: np.ndarray) -> bytes:
     """Serialize a numpy array into bytes."""
+
+    if "cv2" not in sys.modules:
+        raise ImportError("opencv python package is not available")
+
     if array.max() > 255:
         raise ValueError("Can only serialize 16bits images")
     if "int" not in str(array.dtype):
         raise ValueError(f"Array dtype must be 'uint8', got {array.dtype}")
+
     success, encoded_array = cv2.imencode(".png", array)
     if not success:
         raise ValueError("Fail to encode array")
+
     return base64.b64encode(encoded_array)
 
 
 def deserialize_img(serialized_array: bytes) -> np.ndarray:
     """Serialize a bytes variable into numpy array."""
+
+    if "cv2" not in sys.modules and "numpy" not in sys.modules:
+        raise ImportError("opencv python package and numpy are not available")
+
     decoded_array = base64.b64decode(serialized_array)
     decoded_array = np.frombuffer(decoded_array, np.uint8)
     decoded_array = cv2.imdecode(decoded_array, cv2.IMREAD_UNCHANGED)
+
     if decoded_array is None:
         raise ValueError("Fail to decode serialized array")
+
     return decoded_array

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -13,10 +13,31 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import sys
+
 import numpy as np
 import pytest
 
 import archipel_utils as utils
+
+
+@pytest.mark.skip(
+    "cv2" not in sys.modules, reason="cv2 available, cannot this import error"
+)
+def test_import_error_from_serialize_img():
+    """Test serialize_img function when opencv not available."""
+    with pytest.raises(ImportError):
+        utils.serialize_img("")
+
+
+@pytest.mark.skip(
+    "cv2" not in sys.modules and "numpy" not in sys.modules,
+    reason="cv2/numpy available, cannot this import error",
+)
+def test_import_error_for_deserialize_img():
+    """Test serialize_img function when opencv/numpy not available."""
+    with pytest.raises(ImportError):
+        utils.deserialize_img("")
 
 
 def test_serialize_deserialize_img():


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/alpineintuition/archipel/blob/master/CHANGELOG.md)?

## What does this PR do?
improve import method when opencv and numpy not available
