### PR TITLE
remove cv2 dependencies

### DIFF
--- a/archipel_utils/__init__.py
+++ b/archipel_utils/__init__.py
@@ -13,19 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import warnings
-
-try:
-    from .data import *  # noqa
-except ImportError:
-    with warnings.catch_warnings():
-        warnings.simplefilter("always", ImportWarning)
-        warnings.warn(
-            "Missing packages, you will not be able to use archipel 'data' "
-            + "utils, others remain usable. To fix: pip install opencv numpy",
-            ImportWarning,
-        )
-
+from .data import *  # noqa
 from .msg import *  # noqa
 from .path import *  # noqa
 from .process import *  # noqa

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ setup(
     keywords=["archipel-utils", "archipel"],
     install_requires=[
         "msgpack>=1.0",
+        "numpy>=1.21",
+        "Pillow>=8.1",
         "pytest>=6.2",
         "pytest-cov>=2.11",
         "pytest-mock>=3.5",

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -21,7 +21,7 @@ import archipel_utils as utils
 
 def test_serialize_deserialize_img():
     """Test serialized and deserialized img."""
-    fake_img = np.random.randint(0, 255, (600, 600, 3))
+    fake_img = np.random.randint(0, 255, (600, 600, 3)).astype(np.uint8)
     serialized_img = utils.serialize_img(fake_img)
     deserialized_img = utils.deserialize_img(serialized_img)
     assert np.equal(fake_img, deserialized_img).all()


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/alpineintuition/archipel/blob/master/CHANGELOG.md)?

## What does this PR do?
Since `cv2` is difficult to have in alpine docker image, we replace opencv dependencies in serialization functions by Pillow. The serialization is slower but the bytes are lighter.
